### PR TITLE
Instruções de instalação via helm chart

### DIFF
--- a/stacks/edu/README.md
+++ b/stacks/edu/README.md
@@ -22,3 +22,14 @@ Após os serviços estarem iniciados:
 * Acesse http://localhost:8080
 * Crie um novo site
 * Acesse http://universidade.localhost
+
+### Helm Chart
+
+Para instalar no Kubernetes (sem Ingress): 
+
+```
+helm repo add plone https://plone.github.io/charts
+kubectl create namespace portalbrasil
+helm install -n portalbrasil portalbrasil plone/plone --set "ingress.enabled=false,frontend.image.repository=ghcr.io/plonegovbr/portal,frontend.image.tag=latest,backend.image.repository=ghcr.io/plonegovbr/portal_edu,backend.image.tag=latest"
+kubectl port-forward -n portalbrasil service/portalbrasil-plone-frontend 3000:3000
+```


### PR DESCRIPTION
Incluir instruções de instalação do Portal Brasil com o novo Helm Chart do Plone 6, disponível em https://github.com/plone/charts.
